### PR TITLE
修复调用downloadFile， wx.env.USER_DATA_PATH后面没有加斜杠

### DIFF
--- a/miniprogram/pages/yaoxh6/posted/posted.js
+++ b/miniprogram/pages/yaoxh6/posted/posted.js
@@ -141,7 +141,7 @@ Page({
         wx.hideLoading()
         console.log(error);
         wx.showToast({
-          title: '下载失败',
+          title: error,
           icon: 'none'
         })
       })
@@ -171,7 +171,7 @@ Page({
     return new Promise((resolve, reject) => {
       wx.downloadFile({
         url: res.fileList[0].tempFileURL,
-        filePath: wx.env.USER_DATA_PATH + this.data['targetQName'] + '问卷结果.xlsx',
+        filePath: wx.env.USER_DATA_PATH + '/' + this.data['targetQName'] + '问卷结果.xlsx',
         success: res => {
           resolve(res)
         },


### PR DESCRIPTION
1. 将下载失败title改为服务端返回值
2. 路径添加'/'得到正确路径